### PR TITLE
ci: inline baseline thresholds in enforcement scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,17 +165,19 @@ cd packages/flutter && flutter test --coverage   # writes coverage/lcov.info
 Two regression-catcher coverage floors are enforced in CI (`coverage.yml`):
 
 - `tools/scripts/coverage-floor.sh lcov.info` — the core public API boundary
-  (`crates/core/src/api/`), baseline `CORE_API_MIN_LINES` in
-  `tools/scripts/coverage-baseline.txt`.
+  (`crates/core/src/api/`), with `CORE_API_MIN_LINES` and
+  `CORE_SRC_MIN_LINES` maintained directly in
+  `tools/scripts/coverage-floor.sh`.
 - `tools/scripts/flutter-coverage-floor.sh packages/flutter/coverage/lcov.info`
-  — the Flutter SDK lib aggregate, baseline `FLUTTER_SDK_MIN_LINES` in
-  `tools/scripts/flutter-coverage-baseline.txt`.
+  — the Flutter SDK lib aggregate, with `FLUTTER_SDK_MIN_LINES` maintained
+  directly in `tools/scripts/flutter-coverage-floor.sh`.
 
-Both floors may only be raised: when CI reports a higher real percentage, bump
-the matching baseline to lock it in. (The Rust floor scopes to `napaxi-core`
-rather than `--workspace` because the vendored `libsql-sqlite3-parser` build
-script breaks under `cargo llvm-cov`'s instrumented target dir, and the api
-boundary lives entirely in `napaxi-core`.)
+Both floors may only be raised: when CI reports a higher real percentage,
+update the matching checked-in minimum in the script to lock it in. (The Rust
+floor scopes to `napaxi-core` rather than `--workspace` because the vendored
+`libsql-sqlite3-parser` build script breaks under `cargo llvm-cov`'s
+instrumented target dir, and the api boundary lives entirely in
+`napaxi-core`.)
 
 ## Pull Request Expectations
 

--- a/tools/scripts/check-test-stability.sh
+++ b/tools/scripts/check-test-stability.sh
@@ -2,13 +2,14 @@
 # Test-stability ratchet for the Napaxi repo.
 #
 # Green CI must not be bought by skipping tests. This guard counts the
-# skip/ignore markers in first-party test code and compares them against a
-# checked-in baseline. The count may only go DOWN: adding a new `#[ignore]`
-# (Rust) or `skip:` (Dart/flutter_test) fails CI until the baseline is
-# lowered in the same change, which forces a reviewer to see the regression.
+# skip/ignore markers in first-party test code and compares them against the
+# checked-in limits defined in this script. The count may only go DOWN: adding
+# a new `#[ignore]` (Rust) or `skip:` (Dart/flutter_test) fails CI until the
+# limit is raised in the same change, which forces a reviewer to see the
+# regression.
 #
-# Lowering the baseline (re-enabling a test) is always allowed and the script
-# nudges you to update the file when you do.
+# Lowering the limits (re-enabling a test) is always allowed and the script
+# nudges you to update the constants when you do.
 #
 # Third-party vendored code under vendor/ is intentionally excluded: we do not
 # police upstream test discipline.
@@ -17,10 +18,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-BASELINE_FILE="$SCRIPT_DIR/test-skip-baseline.txt"
 
 info() { printf '[INFO] %s\n' "$*"; }
 err()  { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+RUST_IGNORE_LIMIT=1
+DART_SKIP_LIMIT=0
 
 require_command() {
     command -v "$1" >/dev/null 2>&1 || err "$1 not found"
@@ -29,8 +32,6 @@ require_command() {
 cd "$ROOT_DIR"
 require_command git
 require_command grep
-
-[ -f "$BASELINE_FILE" ] || err "Missing baseline file: $BASELINE_FILE"
 
 # First-party test files only (exclude vendored third-party code), one per
 # line. Newline-separated so we stay portable to bash 3.2 (no mapfile).
@@ -64,20 +65,9 @@ RUST_IGNORE=$(count_pattern '#\[ignore' "$RUST_FILES")
 # Dart/flutter_test `skip:` argument on test()/testWidgets()/group().
 DART_SKIP=$(count_pattern 'skip:' "$DART_FILES")
 
-# Read expected values from the baseline file (KEY=VALUE lines, '#' comments).
-read_baseline() {
-    local key="$1"
-    grep -E "^${key}=" "$BASELINE_FILE" | head -1 | cut -d= -f2 | tr -d '[:space:]'
-}
-BASE_RUST=$(read_baseline RUST_IGNORE)
-BASE_DART=$(read_baseline DART_SKIP)
-
-[ -n "$BASE_RUST" ] || err "Baseline missing RUST_IGNORE= line in $BASELINE_FILE"
-[ -n "$BASE_DART" ] || err "Baseline missing DART_SKIP= line in $BASELINE_FILE"
-
 info "Test-stability counts (first-party, vendor excluded):"
-info "  Rust  #[ignore] : current=$RUST_IGNORE baseline=$BASE_RUST"
-info "  Dart  skip:      : current=$DART_SKIP baseline=$BASE_DART"
+info "  Rust  #[ignore] : current=$RUST_IGNORE limit=$RUST_IGNORE_LIMIT"
+info "  Dart  skip:      : current=$DART_SKIP limit=$DART_SKIP_LIMIT"
 
 # Visibility: list exactly where the skips/ignores live so reviewers see them.
 if [ "$RUST_IGNORE" -gt 0 ]; then
@@ -90,19 +80,19 @@ if [ "$DART_SKIP" -gt 0 ]; then
 fi
 
 fail=0
-if [ "$RUST_IGNORE" -gt "$BASE_RUST" ]; then
-    printf '[ERROR] Rust #[ignore] count rose from %s to %s. Do not skip tests to make CI green.\n' "$BASE_RUST" "$RUST_IGNORE" >&2
+if [ "$RUST_IGNORE" -gt "$RUST_IGNORE_LIMIT" ]; then
+    printf '[ERROR] Rust #[ignore] count rose above the limit (%s -> %s). Do not skip tests to make CI green.\n' "$RUST_IGNORE_LIMIT" "$RUST_IGNORE" >&2
     fail=1
 fi
-if [ "$DART_SKIP" -gt "$BASE_DART" ]; then
-    printf '[ERROR] Dart skip: count rose from %s to %s. Do not skip tests to make CI green.\n' "$BASE_DART" "$DART_SKIP" >&2
+if [ "$DART_SKIP" -gt "$DART_SKIP_LIMIT" ]; then
+    printf '[ERROR] Dart skip: count rose above the limit (%s -> %s). Do not skip tests to make CI green.\n' "$DART_SKIP_LIMIT" "$DART_SKIP" >&2
     fail=1
 fi
-[ "$fail" -eq 0 ] || err "Test-stability ratchet violated. If a skip is unavoidable, justify it in review and update $BASELINE_FILE."
+[ "$fail" -eq 0 ] || err "Test-stability ratchet violated. If a skip is unavoidable, justify it in review and update the limits in tools/scripts/check-test-stability.sh."
 
 # Encourage tightening the ratchet when skips are removed.
-if [ "$RUST_IGNORE" -lt "$BASE_RUST" ] || [ "$DART_SKIP" -lt "$BASE_DART" ]; then
-    info "Skip count dropped below baseline — lower the numbers in $BASELINE_FILE to lock in the improvement."
+if [ "$RUST_IGNORE" -lt "$RUST_IGNORE_LIMIT" ] || [ "$DART_SKIP" -lt "$DART_SKIP_LIMIT" ]; then
+    info "Skip count dropped below the checked-in limits — lower the constants in tools/scripts/check-test-stability.sh to lock in the improvement."
 fi
 
 info "Test-stability ratchet passed"

--- a/tools/scripts/coverage-floor.sh
+++ b/tools/scripts/coverage-floor.sh
@@ -8,33 +8,26 @@
 # This script parses an lcov file (produced by `cargo llvm-cov --lcov`),
 # computes the line-coverage percentage for files under
 # `crates/core/src/api/`, ALWAYS prints it, and fails if it is below the
-# floor recorded in tools/scripts/coverage-baseline.txt.
+# checked-in floors defined in this script.
 #
 # The floor starts deliberately conservative: it is a regression catcher
 # (e.g. "someone deleted the API tests"), not a quality target. Once CI
-# reports the real number, raise CORE_API_MIN_LINES in the baseline file to
-# lock in the actual coverage. The number may only go UP.
+# reports the real number, raise the checked-in minimums here to lock in the
+# actual coverage. The numbers may only go UP.
 #
 # Usage: coverage-floor.sh <lcov-file>
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BASELINE_FILE="$SCRIPT_DIR/coverage-baseline.txt"
-
 info() { printf '[INFO] %s\n' "$*"; }
 err()  { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+CORE_API_MIN_LINES=99
+CORE_SRC_MIN_LINES=76
 
 LCOV_FILE="${1:-}"
 [ -n "$LCOV_FILE" ] || err "Usage: coverage-floor.sh <lcov-file>"
 [ -f "$LCOV_FILE" ] || err "lcov file not found: $LCOV_FILE"
-[ -f "$BASELINE_FILE" ] || err "Missing baseline file: $BASELINE_FILE"
-
-FLOOR="$(grep -E '^CORE_API_MIN_LINES=' "$BASELINE_FILE" | head -1 | cut -d= -f2 | tr -d '[:space:]')"
-[ -n "$FLOOR" ] || err "Baseline missing CORE_API_MIN_LINES= line in $BASELINE_FILE"
-
-SRC_FLOOR="$(grep -E '^CORE_SRC_MIN_LINES=' "$BASELINE_FILE" | head -1 | cut -d= -f2 | tr -d '[:space:]')"
-[ -n "$SRC_FLOOR" ] || err "Baseline missing CORE_SRC_MIN_LINES= line in $BASELINE_FILE"
 
 # Sum DA: (line-hit) records for files matching a path substring.
 # lcov format: `SF:<path>` opens a file section; `DA:<line>,<hits>` per line;
@@ -71,14 +64,14 @@ fi
 # Integer percentage (floored) to avoid bc/float dependency.
 PCT=$(( COVERED * 100 / TOTAL ))
 
-info "Core API boundary line coverage: ${PCT}% (${COVERED}/${TOTAL} lines) — floor ${FLOOR}%"
+info "Core API boundary line coverage: ${PCT}% (${COVERED}/${TOTAL} lines) — floor ${CORE_API_MIN_LINES}%"
 
-if [ "$PCT" -lt "$FLOOR" ]; then
-    err "Core API coverage ${PCT}% is below the floor of ${FLOOR}%. Add tests for crates/core/src/api/, or justify lowering the floor in review."
+if [ "$PCT" -lt "$CORE_API_MIN_LINES" ]; then
+    err "Core API coverage ${PCT}% is below the floor of ${CORE_API_MIN_LINES}%. Add tests for crates/core/src/api/, or justify lowering the floor in review."
 fi
 
-if [ "$PCT" -gt "$FLOOR" ]; then
-    info "Coverage exceeds the floor — raise CORE_API_MIN_LINES in $BASELINE_FILE to ${PCT} to lock it in."
+if [ "$PCT" -gt "$CORE_API_MIN_LINES" ]; then
+    info "Coverage exceeds the floor — raise CORE_API_MIN_LINES in tools/scripts/coverage-floor.sh to ${PCT} to lock it in."
 fi
 
 # --- Floor 2: the whole napaxi-core src (catches the execution layer) ---------
@@ -92,14 +85,14 @@ fi
 
 SRC_PCT=$(( SRC_COVERED * 100 / SRC_TOTAL ))
 
-info "napaxi-core/src line coverage: ${SRC_PCT}% (${SRC_COVERED}/${SRC_TOTAL} lines) — floor ${SRC_FLOOR}%"
+info "napaxi-core/src line coverage: ${SRC_PCT}% (${SRC_COVERED}/${SRC_TOTAL} lines) — floor ${CORE_SRC_MIN_LINES}%"
 
-if [ "$SRC_PCT" -lt "$SRC_FLOOR" ]; then
-    err "napaxi-core/src coverage ${SRC_PCT}% is below the floor of ${SRC_FLOOR}%. The core execution layer (turn/llm/mcp/...) regressed; add tests or justify lowering the floor in review."
+if [ "$SRC_PCT" -lt "$CORE_SRC_MIN_LINES" ]; then
+    err "napaxi-core/src coverage ${SRC_PCT}% is below the floor of ${CORE_SRC_MIN_LINES}%. The core execution layer (turn/llm/mcp/...) regressed; add tests or justify lowering the floor in review."
 fi
 
-if [ "$SRC_PCT" -gt "$SRC_FLOOR" ]; then
-    info "Whole-src coverage exceeds the floor — raise CORE_SRC_MIN_LINES in $BASELINE_FILE to ${SRC_PCT} to lock it in."
+if [ "$SRC_PCT" -gt "$CORE_SRC_MIN_LINES" ]; then
+    info "Whole-src coverage exceeds the floor — raise CORE_SRC_MIN_LINES in tools/scripts/coverage-floor.sh to ${SRC_PCT} to lock it in."
 fi
 
 info "Core coverage floors passed"

--- a/tools/scripts/flutter-coverage-floor.sh
+++ b/tools/scripts/flutter-coverage-floor.sh
@@ -4,11 +4,11 @@
 # Mirrors tools/scripts/coverage-floor.sh (the Rust core-API floor) for the
 # Dart side: parses the lcov produced by `flutter test --coverage`, computes
 # the overall line-coverage percentage for packages/flutter/lib, ALWAYS prints
-# it, and fails if it is below the floor in flutter-coverage-baseline.txt.
+# it, and fails if it is below the checked-in floor defined in this script.
 #
 # Like the Rust floor, this is a regression catcher (e.g. "someone deleted the
-# model tests"), not a quality target. The number may only go UP: raise
-# FLUTTER_SDK_MIN_LINES when real coverage improves to lock it in.
+# model tests"), not a quality target. The number may only go UP: raise the
+# checked-in minimum when real coverage improves to lock it in.
 #
 # Note: the api/*.dart FFI wrappers are thin pass-throughs exercised through
 # integration, not unit tests, so they sit near 0% and pull the aggregate down.
@@ -19,19 +19,14 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BASELINE_FILE="$SCRIPT_DIR/flutter-coverage-baseline.txt"
-
 info() { printf '[INFO] %s\n' "$*"; }
 err()  { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+FLUTTER_SDK_MIN_LINES=35
 
 LCOV_FILE="${1:-}"
 [ -n "$LCOV_FILE" ] || err "Usage: flutter-coverage-floor.sh <lcov-file>"
 [ -f "$LCOV_FILE" ] || err "lcov file not found: $LCOV_FILE"
-[ -f "$BASELINE_FILE" ] || err "Missing baseline file: $BASELINE_FILE"
-
-FLOOR="$(grep -E '^FLUTTER_SDK_MIN_LINES=' "$BASELINE_FILE" | head -1 | cut -d= -f2 | tr -d '[:space:]')"
-[ -n "$FLOOR" ] || err "Baseline missing FLUTTER_SDK_MIN_LINES= line in $BASELINE_FILE"
 
 # Sum all DA: line-hit records (flutter coverage already scopes to lib/).
 read_counts() {
@@ -55,14 +50,14 @@ fi
 
 PCT=$(( COVERED * 100 / TOTAL ))
 
-info "Flutter SDK line coverage: ${PCT}% (${COVERED}/${TOTAL} lines) — floor ${FLOOR}%"
+info "Flutter SDK line coverage: ${PCT}% (${COVERED}/${TOTAL} lines) — floor ${FLUTTER_SDK_MIN_LINES}%"
 
-if [ "$PCT" -lt "$FLOOR" ]; then
-    err "Flutter SDK coverage ${PCT}% is below the floor of ${FLOOR}%. Add tests under packages/flutter, or justify lowering the floor in review."
+if [ "$PCT" -lt "$FLUTTER_SDK_MIN_LINES" ]; then
+    err "Flutter SDK coverage ${PCT}% is below the floor of ${FLUTTER_SDK_MIN_LINES}%. Add tests under packages/flutter, or justify lowering the floor in review."
 fi
 
-if [ "$PCT" -gt "$FLOOR" ]; then
-    info "Coverage exceeds the floor — raise FLUTTER_SDK_MIN_LINES in $BASELINE_FILE to ${PCT} to lock it in."
+if [ "$PCT" -gt "$FLUTTER_SDK_MIN_LINES" ]; then
+    info "Coverage exceeds the floor — raise FLUTTER_SDK_MIN_LINES in tools/scripts/flutter-coverage-floor.sh to ${PCT} to lock it in."
 fi
 
 info "Flutter SDK coverage floor passed"


### PR DESCRIPTION
## Summary
- inline the Rust coverage floors into `tools/scripts/coverage-floor.sh`
- inline the Flutter coverage floor and test-stability limits into their scripts
- update contributor docs to point at script constants instead of deleted baseline files

## Why
The baseline text files were removed, but the enforcement scripts still required them at runtime. That makes CI fail before it can evaluate coverage or skip counts.

## Validation
- `./tools/scripts/coverage-floor.sh` with a temporary lcov fixture
- `./tools/scripts/flutter-coverage-floor.sh` with a temporary lcov fixture
- `./tools/scripts/check-test-stability.sh`
- `bash -n tools/scripts/coverage-floor.sh tools/scripts/flutter-coverage-floor.sh tools/scripts/check-test-stability.sh`