### PR TITLE
fix: make SDK parser generation fallback deterministic

### DIFF
--- a/vendor/libsql-sqlite3-parser-patched/NAPAXI-PATCH.md
+++ b/vendor/libsql-sqlite3-parser-patched/NAPAXI-PATCH.md
@@ -32,9 +32,11 @@ without it, the `libsql` patch would not compile.
 
 ### Cargo.toml / build system
 
-- **No** source-level deviations from upstream. The `Cargo.toml` is the
-  cargo-normalized form; `Cargo.toml.orig` is the original.
-- The `CMakeLists.txt` and `build.rs` are present as distributed by upstream.
+- `Cargo.toml` is the cargo-normalized form; `Cargo.toml.orig` is the original.
+- `build.rs` keeps the upstream lemon generation path, but falls back to the
+  vendored `generated/parse.rs` when the host-side lemon compiler cannot be
+  built or executed. This keeps mobile SDK release builds deterministic on
+  constrained macOS/CI hosts.
 
 If a future mobile-specific source patch becomes necessary, add a numbered
 entry here in the same shape as the `libsql-patched/NAPAXI-PATCH.md` convention

--- a/vendor/libsql-sqlite3-parser-patched/build.rs
+++ b/vendor/libsql-sqlite3-parser-patched/build.rs
@@ -15,32 +15,34 @@ fn main() -> Result<()> {
     let lemon_src_dir = Path::new("third_party").join("lemon");
     let rlemon_src = lemon_src_dir.join("lemon.c");
 
-    // compile rlemon:
+    let sql_parser = "src/parser/parse.y";
+    let mut generated_parser = false;
+
+    // Compile and run rlemon when the host toolchain supports it. Mobile
+    // release builds can run in constrained environments, so keep the vendored
+    // prebuilt parser as a deterministic fallback.
+    if let Ok(status) = Build::new()
+        .target(&env::var("HOST").unwrap())
+        .get_compiler()
+        .to_command()
+        .arg("-o")
+        .arg(rlemon.clone())
+        .arg(rlemon_src)
+        .status()
     {
-        assert!(Build::new()
-            .target(&env::var("HOST").unwrap())
-            .get_compiler()
-            .to_command()
-            .arg("-o")
-            .arg(rlemon.clone())
-            .arg(rlemon_src)
-            .status()?
-            .success());
+        if status.success() {
+            let status = Command::new(rlemon)
+                .arg("-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT")
+                .arg("-Tthird_party/lemon/lempar.rs")
+                .arg(format!("-d{out_dir}"))
+                .arg(sql_parser)
+                .status()?;
+            generated_parser = status.success();
+        }
     }
 
-    let sql_parser = "src/parser/parse.y";
-    // run rlemon / generate parser:
-    {
-        let status = Command::new(rlemon)
-            .arg("-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT")
-            .arg("-Tthird_party/lemon/lempar.rs")
-            .arg(format!("-d{out_dir}"))
-            .arg(sql_parser)
-            .status()?;
-        if !status.success() {
-            copy_prebuilt_parser(out_path)?;
-        }
-        // TODO ./rlemon -m -Tthird_party/lemon/lempar.rs examples/simple.y
+    if !generated_parser {
+        copy_prebuilt_parser(out_path)?;
     }
 
     let keywords = out_path.join("keywords.rs");
@@ -215,8 +217,6 @@ fn main() -> Result<()> {
 
 fn copy_prebuilt_parser(out_path: &Path) -> Result<()> {
     let generated_dir = Path::new("generated");
-    for file_name in ["parse.rs", "parse.h"] {
-        fs::copy(generated_dir.join(file_name), out_path.join(file_name))?;
-    }
+    fs::copy(generated_dir.join("parse.rs"), out_path.join("parse.rs"))?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add a deterministic fallback for the vendored libsql SQLite parser generation.
- Use the vendored prebuilt parser when the host-side lemon compiler cannot be built or executed.
- Document the Napaxi-specific vendor patch.

## Validation

- `./tools/scripts/build.sh release android`
- `./tools/scripts/build.sh release ios-all`

Both SDK release builds completed successfully and produced the Android `.so` and iOS `.xcframework` artifacts.