### PR TITLE
feat(flutter): add GitHub update fallback

### DIFF
--- a/examples/flutter/README.md
+++ b/examples/flutter/README.md
@@ -38,12 +38,17 @@ Release Android builds should pass the update and contact-service defines:
 flutter build apk --release \
   --dart-define=PGYER_API_KEY=your_pgyer_api_key \
   --dart-define=PGYER_APP_KEY=your_pgyer_app_key \
+  --dart-define=GITHUB_RELEASES_URL=https://github.com/antgroup/Napaxi/releases \
   --dart-define=CONTACT_URL=your_contact_config_url
 ```
 
 `CONTACT_URL` should be supplied by the release environment, the same way as the
 Pgyer keys, so packaged configuration is easy to audit without hard-coding
 deployment URLs in source.
+
+`GITHUB_RELEASES_URL` is optional. When Pgyer is unavailable for a self-built
+package, the About page can fall back to this releases page and let users
+download the latest build manually.
 
 Validate it with:
 

--- a/examples/flutter/lib/app/strings.dart
+++ b/examples/flutter/lib/app/strings.dart
@@ -196,6 +196,9 @@ class AppStrings {
     required this.updateUnknownError,
     required this.updateNoticeClose,
     required this.openInstallPage,
+    required this.openReleasePage,
+    required this.updateReleasePagePrompt,
+    required this.releasePageOpenFailed,
     required this.feedbackTitle,
     required this.feedbackContentLabel,
     required this.feedbackContentHint,
@@ -523,6 +526,9 @@ class AppStrings {
   final String updateUnknownError;
   final String updateNoticeClose;
   final String openInstallPage;
+  final String openReleasePage;
+  final String updateReleasePagePrompt;
+  final String releasePageOpenFailed;
   final String feedbackTitle;
   final String feedbackContentLabel;
   final String feedbackContentHint;
@@ -878,6 +884,10 @@ class AppStrings {
     updateUnknownError: 'Unknown error',
     updateNoticeClose: 'Got it',
     openInstallPage: 'Open Pgyer page',
+    openReleasePage: 'Open GitHub Releases',
+    updateReleasePagePrompt:
+        'This build does not support automatic in-app updates. Open GitHub Releases to download the latest package manually?',
+    releasePageOpenFailed: 'Could not open the GitHub Releases page.',
     feedbackTitle: 'Feedback',
     feedbackContentLabel: 'Issue',
     feedbackContentHint: 'Tell us what happened.',
@@ -1224,6 +1234,10 @@ class AppStrings {
     updateUnknownError: '未知错误',
     updateNoticeClose: '知道了',
     openInstallPage: '打开蒲公英页面',
+    openReleasePage: '打开 GitHub 发布页',
+    updateReleasePagePrompt:
+        '当前构建不支持自动应用内更新，是否前往 GitHub 发布页手动下载最新安装包？',
+    releasePageOpenFailed: '无法打开 GitHub 发布页。',
     feedbackTitle: '问题反馈',
     feedbackContentLabel: '问题描述',
     feedbackContentHint: '请描述遇到的问题。',

--- a/examples/flutter/lib/app/update_service.dart
+++ b/examples/flutter/lib/app/update_service.dart
@@ -113,6 +113,7 @@ class DemoUpdateInstallResult {
 
 abstract class DemoUpdateService {
   bool get supportsUpdateCheck;
+  bool get supportsExternalUpdatePage;
 
   Future<DemoAppVersion> currentVersion();
 
@@ -128,6 +129,7 @@ abstract class DemoUpdateService {
   });
 
   Future<bool> openInstallPage(DemoUpdateInfo update);
+  Future<bool> openExternalUpdatePage();
 }
 
 class PgyerDemoUpdateService implements DemoUpdateService {
@@ -139,6 +141,10 @@ class PgyerDemoUpdateService implements DemoUpdateService {
   static const _appKey = String.fromEnvironment('PGYER_APP_KEY');
   static const _channelKey = String.fromEnvironment('PGYER_CHANNEL_KEY');
   static const _buildPassword = String.fromEnvironment('PGYER_BUILD_PASSWORD');
+  static const _githubReleasesUrl = String.fromEnvironment(
+    'GITHUB_RELEASES_URL',
+    defaultValue: 'https://github.com/antgroup/Napaxi/releases',
+  );
   static const _skippedBuildKey = 'napaxi.pgyer.skipped_build_key.v1';
   static const _requestTimeout = Duration(seconds: 15);
   static const _downloadChunkTimeout = Duration(seconds: 15);
@@ -152,6 +158,10 @@ class PgyerDemoUpdateService implements DemoUpdateService {
 
   @override
   bool get supportsUpdateCheck => Platform.isAndroid;
+
+  @override
+  bool get supportsExternalUpdatePage =>
+      Platform.isAndroid && _externalUpdateUri != null;
 
   @override
   Future<DemoAppVersion> currentVersion() async {
@@ -168,22 +178,22 @@ class PgyerDemoUpdateService implements DemoUpdateService {
   Future<DemoUpdateCheckResult> checkForUpdate({
     required bool respectSkippedVersion,
   }) async {
+    final version = await currentVersion();
     if (!Platform.isAndroid) {
-      return const DemoUpdateCheckResult(
-        currentVersion: DemoAppVersion(version: 'unknown', buildNumber: ''),
+      return DemoUpdateCheckResult(
+        currentVersion: version,
         unsupported: true,
         message: 'Update checking is only supported on Android.',
       );
     }
     if (!_isConfigured) {
-      return const DemoUpdateCheckResult(
-        currentVersion: DemoAppVersion(version: 'unknown', buildNumber: ''),
+      return DemoUpdateCheckResult(
+        currentVersion: version,
         unconfigured: true,
         message: 'Pgyer update checking is not configured.',
       );
     }
 
-    final version = await currentVersion();
     final buildNumber = int.tryParse(version.buildNumber);
     final body = <String, String>{
       '_api_key': _apiKey,
@@ -327,6 +337,17 @@ class PgyerDemoUpdateService implements DemoUpdateService {
     }
   }
 
+  @override
+  Future<bool> openExternalUpdatePage() async {
+    final uri = _externalUpdateUri;
+    if (uri == null) return false;
+    try {
+      return await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<String?> _loadSkippedBuildKey() async {
     final preferences = await _loadPreferences();
     return preferences.getString(_skippedBuildKey);
@@ -356,5 +377,11 @@ class PgyerDemoUpdateService implements DemoUpdateService {
           },
         )
         .toString();
+  }
+
+  Uri? get _externalUpdateUri {
+    final trimmed = _githubReleasesUrl.trim();
+    if (trimmed.isEmpty) return null;
+    return Uri.tryParse(trimmed);
   }
 }

--- a/examples/flutter/lib/screens/chat_screen.dart
+++ b/examples/flutter/lib/screens/chat_screen.dart
@@ -823,6 +823,12 @@ class _ChatScreenState extends State<ChatScreen>
         return;
       }
       if (!result.hasUpdate) {
+        if (!automatic &&
+            result.unconfigured &&
+            widget.updateService.supportsExternalUpdatePage) {
+          await _showReleasePageDialog();
+          return;
+        }
         final message =
             result.message ??
             (result.unconfigured || result.unsupported
@@ -963,6 +969,15 @@ class _ChatScreenState extends State<ChatScreen>
                         unawaited(widget.updateService.openInstallPage(update));
                       },
                       child: Text(strings.openInstallPage),
+                    ),
+                  if (stage == _UpdateInstallStage.failed &&
+                      widget.updateService.supportsExternalUpdatePage)
+                    TextButton(
+                      key: const Key('open_release_page_button'),
+                      onPressed: () {
+                        unawaited(_showReleasePageDialog());
+                      },
+                      child: Text(strings.openReleasePage),
                     ),
                   if (stage == _UpdateInstallStage.installerOpened ||
                       stage == _UpdateInstallStage.permissionRequired)
@@ -1277,6 +1292,34 @@ class _ChatScreenState extends State<ChatScreen>
         );
       },
     );
+  }
+
+  Future<void> _showReleasePageDialog() async {
+    final strings = AppStrings.of(context);
+    final shouldOpen = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(strings.checkForUpdates),
+          content: Text(strings.updateReleasePagePrompt),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+            ),
+            FilledButton(
+              key: const Key('confirm_open_release_page_button'),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(strings.openReleasePage),
+            ),
+          ],
+        );
+      },
+    );
+    if (shouldOpen != true || !mounted) return;
+    final opened = await widget.updateService.openExternalUpdatePage();
+    if (!mounted || opened) return;
+    await _showUpdateNoticeDialog(strings.releasePageOpenFailed);
   }
 
   Future<void> _loadSessionHistory(String sessionId) async {
@@ -1742,6 +1785,7 @@ class _ChatScreenState extends State<ChatScreen>
     return run != null && !run.isTerminal;
   }
 
+  @override
   bool get _usesInjectedChatClient => widget.chatClientFactory != null;
 
   void _handleConfigChanged(LlmConfigState config) {

--- a/examples/flutter/test/test_support.dart
+++ b/examples/flutter/test/test_support.dart
@@ -1855,6 +1855,12 @@ class FakeDemoUpdateService implements DemoUpdateService {
     this.update,
     this.noUpdateMessage,
     this.supportsUpdateCheck = true,
+    this.supportsExternalUpdatePage = false,
+    this.unconfigured = false,
+    this.installResult = const DemoUpdateInstallResult(
+      success: true,
+      installerOpened: true,
+    ),
   });
 
   DemoAppVersion version;
@@ -1862,11 +1868,16 @@ class FakeDemoUpdateService implements DemoUpdateService {
   String? noUpdateMessage;
   @override
   final bool supportsUpdateCheck;
+  @override
+  final bool supportsExternalUpdatePage;
+  final bool unconfigured;
+  DemoUpdateInstallResult installResult;
   String? skippedIdentity;
   var checkCount = 0;
   var skipCount = 0;
   var installCount = 0;
   var openPageCount = 0;
+  var openExternalPageCount = 0;
   final respectSkippedValues = <bool>[];
 
   @override
@@ -1883,6 +1894,7 @@ class FakeDemoUpdateService implements DemoUpdateService {
       return DemoUpdateCheckResult(
         currentVersion: version,
         message: noUpdateMessage,
+        unconfigured: unconfigured,
       );
     }
     if (respectSkippedVersion &&
@@ -1913,12 +1925,18 @@ class FakeDemoUpdateService implements DemoUpdateService {
   }) async {
     installCount += 1;
     onProgress?.call(100, 100);
-    return const DemoUpdateInstallResult(success: true, installerOpened: true);
+    return installResult;
   }
 
   @override
   Future<bool> openInstallPage(DemoUpdateInfo update) async {
     openPageCount += 1;
+    return true;
+  }
+
+  @override
+  Future<bool> openExternalUpdatePage() async {
+    openExternalPageCount += 1;
     return true;
   }
 }

--- a/examples/flutter/test/widget_test.dart
+++ b/examples/flutter/test/widget_test.dart
@@ -5799,6 +5799,34 @@ void main() {
     expect(find.text('Update available'), findsOneWidget);
   });
 
+  testWidgets('manual update check offers GitHub releases for self-built app', (
+    tester,
+  ) async {
+    final updates = FakeDemoUpdateService(
+      supportsExternalUpdatePage: true,
+      unconfigured: true,
+    );
+
+    await tester.pumpWidget(_testApp(updateService: updates));
+    await tester.pumpAndSettle();
+
+    await openAbout(tester);
+    await tester.tap(find.byKey(const Key('about_check_update_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'This build does not support automatic in-app updates. Open GitHub Releases to download the latest package manually?',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('confirm_open_release_page_button')));
+    await tester.pumpAndSettle();
+
+    expect(updates.openExternalPageCount, 1);
+  });
+
   testWidgets('update install keeps status visible until acknowledged', (
     tester,
   ) async {
@@ -5842,6 +5870,67 @@ void main() {
     expect(find.text('Update available'), findsOneWidget);
     expect(find.text('This update is required.'), findsOneWidget);
     expect(find.byKey(const Key('update_later_button')), findsNothing);
+  });
+
+  testWidgets('failed install can fall back to GitHub releases', (tester) async {
+    final updates = FakeDemoUpdateService(
+      supportsExternalUpdatePage: true,
+      installResult: const DemoUpdateInstallResult(
+        success: false,
+        message: 'Download failed.',
+      ),
+      update: const DemoUpdateInfo(
+        buildKey: 'build-6',
+        buildVersion: '0.0.6',
+        buildVersionNo: '6',
+        buildBuildVersion: 6,
+        needForceUpdate: false,
+        downloadUrl: 'https://example.com/app.apk',
+        appUrl: '',
+        updateDescription: 'Bug fixes and polish.',
+        fileSizeBytes: 12345678,
+      ),
+    );
+
+    await tester.pumpWidget(_testApp(updateService: updates));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('install_update_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('open_release_page_button')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('open_release_page_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'This build does not support automatic in-app updates. Open GitHub Releases to download the latest package manually?',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('failed install shows both Pgyer and GitHub fallback actions', (
+    tester,
+  ) async {
+    final updates = FakeDemoUpdateService(
+      supportsExternalUpdatePage: true,
+      installResult: const DemoUpdateInstallResult(
+        success: false,
+        message: 'Download failed.',
+      ),
+      update: demoUpdate,
+    );
+
+    await tester.pumpWidget(_testApp(updateService: updates));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('install_update_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('open_pgyer_install_page_button')), findsOneWidget);
+    expect(find.byKey(const Key('open_release_page_button')), findsOneWidget);
   });
 
   testWidgets('favorites and unfavorites chat attachments from the side menu', (


### PR DESCRIPTION
## Summary
- add a GitHub Releases fallback for self-built Android packages when in-app Pgyer update checks are unavailable
- keep Pgyer as the primary update path while also exposing GitHub Releases as a backup action after update failures
- document the optional `GITHUB_RELEASES_URL` define and add widget coverage for the new update flows

## Testing
- flutter analyze lib/app/update_service.dart lib/app/strings.dart lib/screens/chat_screen.dart test/test_support.dart test/widget_test.dart
- flutter test --no-pub test/widget_test.dart --plain-name "manual update check offers GitHub releases for self-built app"
- flutter test --no-pub test/widget_test.dart --plain-name "failed install can fall back to GitHub releases"
- flutter test --no-pub test/widget_test.dart --plain-name "failed install shows both Pgyer and GitHub fallback actions"
- flutter test --no-pub test/widget_test.dart --plain-name "update install keeps status visible until acknowledged"