### PR TITLE
fix(android): detect Git Bash automatically on Windows builds

### DIFF
--- a/packages/android/build.gradle.kts
+++ b/packages/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+
 plugins {
     id("com.android.library") version "8.11.1"
     id("org.jetbrains.kotlin.android") version "2.2.20"
@@ -48,63 +50,50 @@ fun Project.resolveWindowsBashPath(): String {
         }
     }
 
-    fun collectWhereResults(executable: String) {
-        try {
-            val output = java.io.ByteArrayOutputStream()
-            exec {
-                commandLine("where.exe", executable)
-                standardOutput = output
-                errorOutput = java.io.ByteArrayOutputStream()
-                isIgnoreExitValue = true
-            }
-            output.toString(Charsets.UTF_8.name())
-                .lineSequence()
-                .map { it.trim() }
-                .filter { it.isNotEmpty() }
-                .forEach(::addCandidate)
-        } catch (_: Exception) {
+    fun addGitRoot(root: String?) {
+        if (!root.isNullOrBlank()) {
+            addCandidate("$root/bin/bash.exe")
+            addCandidate("$root/usr/bin/bash.exe")
         }
     }
 
     addCandidate(System.getenv("NAPAXI_BASH"))
-    collectWhereResults("bash")
 
-    try {
-        val output = java.io.ByteArrayOutputStream()
-        exec {
-            commandLine("where.exe", "git")
-            standardOutput = output
-            errorOutput = java.io.ByteArrayOutputStream()
-            isIgnoreExitValue = true
-        }
-        output.toString(Charsets.UTF_8.name())
-            .lineSequence()
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-            .forEach { gitPath ->
-                val gitExe = file(gitPath)
-                val gitRoot = gitExe.parentFile?.parentFile
-                if (gitRoot != null) {
-                    addCandidate(java.io.File(gitRoot, "bin/bash.exe").path)
-                    addCandidate(java.io.File(gitRoot, "usr/bin/bash.exe").path)
-                }
+    val pathEntries: List<String> = (System.getenv("PATH") ?: "")
+        .split(File.pathSeparatorChar)
+        .map { pathEntry: String -> pathEntry.trim() }
+        .filter { pathEntry: String -> pathEntry.isNotEmpty() }
+
+    pathEntries.forEach { entry: String ->
+        addCandidate("$entry/bash.exe")
+
+        val entryDir = file(entry)
+        val entryName = entryDir.name.lowercase()
+        if (entryName == "cmd") {
+            addGitRoot(entryDir.parentFile?.path)
+        } else if (entryName == "bin") {
+            val parent = entryDir.parentFile
+            if (parent?.name.equals("usr", ignoreCase = true)) {
+                addGitRoot(parent?.parentFile?.path)
+            } else {
+                addGitRoot(parent?.path)
             }
-    } catch (_: Exception) {
+        } else if (entryName == "usr") {
+            addGitRoot(entryDir.parentFile?.path)
+        }
     }
 
     listOf("ProgramFiles", "ProgramFiles(x86)")
         .mapNotNull { System.getenv(it) }
         .filter { it.isNotBlank() }
         .forEach { root ->
-            addCandidate(java.io.File(root, "Git/bin/bash.exe").path)
-            addCandidate(java.io.File(root, "Git/usr/bin/bash.exe").path)
+            addGitRoot("$root/Git")
         }
 
     System.getenv("LocalAppData")
         ?.takeIf { it.isNotBlank() }
         ?.let { localAppData ->
-            addCandidate(java.io.File(localAppData, "Programs/Git/bin/bash.exe").path)
-            addCandidate(java.io.File(localAppData, "Programs/Git/usr/bin/bash.exe").path)
+            addGitRoot("$localAppData/Programs/Git")
         }
 
     val windowsBash = file("${System.getenv("WINDIR") ?: "C:/Windows"}/System32/bash.exe")

--- a/packages/android/build.gradle.kts
+++ b/packages/android/build.gradle.kts
@@ -39,6 +39,89 @@ kotlin {
     }
 }
 
+fun Project.resolveWindowsBashPath(): String {
+    val candidates = linkedSetOf<String>()
+
+    fun addCandidate(path: String?) {
+        if (!path.isNullOrBlank()) {
+            candidates += path.trim()
+        }
+    }
+
+    fun collectWhereResults(executable: String) {
+        try {
+            val output = java.io.ByteArrayOutputStream()
+            exec {
+                commandLine("where.exe", executable)
+                standardOutput = output
+                errorOutput = java.io.ByteArrayOutputStream()
+                isIgnoreExitValue = true
+            }
+            output.toString(Charsets.UTF_8.name())
+                .lineSequence()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .forEach(::addCandidate)
+        } catch (_: Exception) {
+        }
+    }
+
+    addCandidate(System.getenv("NAPAXI_BASH"))
+    collectWhereResults("bash")
+
+    try {
+        val output = java.io.ByteArrayOutputStream()
+        exec {
+            commandLine("where.exe", "git")
+            standardOutput = output
+            errorOutput = java.io.ByteArrayOutputStream()
+            isIgnoreExitValue = true
+        }
+        output.toString(Charsets.UTF_8.name())
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .forEach { gitPath ->
+                val gitExe = file(gitPath)
+                val gitRoot = gitExe.parentFile?.parentFile
+                if (gitRoot != null) {
+                    addCandidate(java.io.File(gitRoot, "bin/bash.exe").path)
+                    addCandidate(java.io.File(gitRoot, "usr/bin/bash.exe").path)
+                }
+            }
+    } catch (_: Exception) {
+    }
+
+    listOf("ProgramFiles", "ProgramFiles(x86)")
+        .mapNotNull { System.getenv(it) }
+        .filter { it.isNotBlank() }
+        .forEach { root ->
+            addCandidate(java.io.File(root, "Git/bin/bash.exe").path)
+            addCandidate(java.io.File(root, "Git/usr/bin/bash.exe").path)
+        }
+
+    System.getenv("LocalAppData")
+        ?.takeIf { it.isNotBlank() }
+        ?.let { localAppData ->
+            addCandidate(java.io.File(localAppData, "Programs/Git/bin/bash.exe").path)
+            addCandidate(java.io.File(localAppData, "Programs/Git/usr/bin/bash.exe").path)
+        }
+
+    val windowsBash = file("${System.getenv("WINDIR") ?: "C:/Windows"}/System32/bash.exe")
+    val windowsBashPath = windowsBash.takeIf { it.exists() }?.canonicalPath
+
+    val bashPath = candidates
+        .map { file(it) }
+        .firstOrNull { candidate ->
+            candidate.exists() &&
+                candidate.name.equals("bash.exe", ignoreCase = true) &&
+                (windowsBashPath == null || !candidate.canonicalPath.equals(windowsBashPath, ignoreCase = true))
+        }
+
+    return bashPath?.absolutePath
+        ?: throw GradleException("No usable Git Bash executable found for tools/scripts/build.sh. Set NAPAXI_BASH to your Git Bash path.")
+}
+
 val flutterAndroidDir = file("../flutter/android")
 val repoRoot = file("../..")
 
@@ -64,7 +147,14 @@ tasks.register<Exec>("buildRust") {
     onlyIf { !soFile.exists() }
     dependsOn("verifySdkNativeInputs")
     workingDir = repoRoot
-    commandLine("${repoRoot}/tools/scripts/build.sh", "fast", "android")
+    val buildScript = file("${repoRoot}/tools/scripts/build.sh")
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+        doFirst {
+            commandLine(resolveWindowsBashPath(), buildScript.absolutePath, "fast", "android")
+        }
+    } else {
+        commandLine(buildScript.absolutePath, "fast", "android")
+    }
 }
 
 tasks.register("verifySdkNativeOutputs") {

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -53,6 +53,95 @@ dependencies {
     compileOnly 'androidx.core:core:1.13.0'
 }
 
+def resolveWindowsBashPath(Project project) {
+    def candidates = []
+    def addCandidate = { String path ->
+        if (path != null && !path.trim().isEmpty()) {
+            candidates << path.trim()
+        }
+    }
+
+    addCandidate(System.getenv("NAPAXI_BASH"))
+
+    def collectWhereResults = { String executable ->
+        try {
+            def output = new ByteArrayOutputStream()
+            project.exec {
+                commandLine "where.exe", executable
+                standardOutput = output
+                errorOutput = new ByteArrayOutputStream()
+                ignoreExitValue = true
+            }
+            output.toString("UTF-8")
+                .readLines()
+                .collect { it.trim() }
+                .findAll { !it.isEmpty() }
+                .each(addCandidate)
+        } catch (Exception ignored) {
+        }
+    }
+
+    collectWhereResults("bash")
+
+    def gitPaths = []
+    try {
+        def output = new ByteArrayOutputStream()
+        project.exec {
+            commandLine "where.exe", "git"
+            standardOutput = output
+            errorOutput = new ByteArrayOutputStream()
+            ignoreExitValue = true
+        }
+        gitPaths = output.toString("UTF-8")
+            .readLines()
+            .collect { it.trim() }
+            .findAll { !it.isEmpty() }
+    } catch (Exception ignored) {
+    }
+
+    gitPaths.each { gitPath ->
+        def gitExe = project.file(gitPath)
+        def gitRoot = gitExe.parentFile?.parentFile
+        if (gitRoot != null) {
+            addCandidate(new File(gitRoot, "bin/bash.exe").path)
+            addCandidate(new File(gitRoot, "usr/bin/bash.exe").path)
+        }
+    }
+
+    [
+        System.getenv("ProgramFiles"),
+        System.getenv("ProgramFiles(x86)")
+    ].findAll { it != null && !it.trim().isEmpty() }
+        .each { root ->
+            addCandidate(new File(root, "Git/bin/bash.exe").path)
+            addCandidate(new File(root, "Git/usr/bin/bash.exe").path)
+        }
+
+    def localAppData = System.getenv("LocalAppData")
+    if (localAppData != null && !localAppData.trim().isEmpty()) {
+        addCandidate(new File(localAppData, "Programs/Git/bin/bash.exe").path)
+        addCandidate(new File(localAppData, "Programs/Git/usr/bin/bash.exe").path)
+    }
+
+    def windowsDir = System.getenv("WINDIR") ?: "C:/Windows"
+    def windowsBash = project.file("${windowsDir}/System32/bash.exe")
+    def windowsBashPath = windowsBash.exists() ? windowsBash.canonicalPath : null
+
+    def bashPath = candidates
+        .collect { project.file(it) }
+        .find { candidate ->
+            candidate.exists() &&
+                candidate.name.equalsIgnoreCase("bash.exe") &&
+                (windowsBashPath == null || !candidate.canonicalPath.equalsIgnoreCase(windowsBashPath))
+        }
+
+    if (bashPath == null) {
+        throw new GradleException("No usable Git Bash executable found for tools/scripts/build.sh. Set NAPAXI_BASH to your Git Bash path.")
+    }
+
+    bashPath.absolutePath
+}
+
 task verifySdkNativeInputs {
     doLast {
         def androidMain = file("${project.projectDir}")
@@ -80,7 +169,14 @@ task buildRust(type: Exec) {
     dependsOn verifySdkNativeInputs
     def repoRoot = file("${project.projectDir}/../../..")
     workingDir repoRoot
-    commandLine "${repoRoot}/tools/scripts/build.sh", "fast", "android"
+    def buildScript = file("${repoRoot}/tools/scripts/build.sh")
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+        doFirst {
+            commandLine resolveWindowsBashPath(project), buildScript.absolutePath, "fast", "android"
+        }
+    } else {
+        commandLine buildScript.absolutePath, "fast", "android"
+    }
 }
 
 task verifySdkNativeOutputs {


### PR DESCRIPTION
## Summary *

Fix Windows Android builds by invoking `tools/scripts/build.sh` through Bash and automatically resolving a usable Git Bash executable instead of relying on host-specific paths. This allows both the Flutter Android package and the native Android integration example to build successfully on Windows without manually hardcoding a local Bash path.

## Motivation

On Windows, the Android build path could fail because Gradle attempted to execute `tools/scripts/build.sh` directly, or because Bash resolution depended on machine-specific locations. This change makes the build flow portable for Windows contributors.

## Scope *

- [ ] Core (`crates/core/`)
- [ ] Feature crate (`crates/features/`)
- [ ] Bridge (`packages/api_bridge/`)
- [x] Flutter SDK (`packages/flutter/`)
- [ ] Agent Provider (`packages/agent_provider/`)
- [x] Demo (`examples/`)
- [ ] Docs / scripts only

## Test Plan *

What I ran locally on Windows:

1. Flutter Android package Rust build validation

   `cd examples/flutter/android`
   `gradlew.bat :napaxi_flutter:buildRust --stacktrace`

   Outcome:
   - Succeeded on Windows without setting `NAPAXI_BASH`
   - Verified the Windows Bash auto-detection path worked for the Flutter Android package build

2. Native Android integration example build

   `cd examples/integration/android`
   `../../flutter/android/gradlew.bat assembleDebug --stacktrace`

   Outcome:
   - `BUILD SUCCESSFUL`
   - Verified the Windows Bash auto-detection path also worked for the native Android SDK integration flow

Not run for this PR:

- [ ] `./tools/scripts/build.sh check-boundary`
- [ ] `cargo check --workspace`
- [ ] `cargo test --workspace` (if behavior changed)
- [ ] `cd packages/flutter && flutter analyze --no-fatal-infos --no-fatal-warnings && flutter test` (if Flutter SDK changed)
- [ ] `cd examples/flutter && flutter analyze --no-fatal-infos --no-fatal-warnings && flutter test` (if demo changed)

## Contributor License Agreement *

- [x] I have completed the applicable CLA, or this PR is from a maintainer using already-approved project-owned code.
- [x] If this contribution is owned or controlled by my employer or another legal entity, the Corporate CLA requirement has been addressed.

## Capability / API Surface

- [ ] Capability defined in `crates/core/src/capabilities/`
- [ ] Adapter wrapper in `crates/core/src/api/`
- [ ] `docs/mobile-capabilities.md` updated
- [x] Public Dart SDK surface in `packages/flutter/lib/napaxi_flutter.dart` unchanged (or breaking change is called out below and added to `CHANGELOG.md`)

## Generated Code

- [x] No hand edits to `packages/flutter/lib/generated/`, `packages/api_bridge/generated/`, or `packages/flutter/ios/Classes/frb_generated.h`
- [ ] If bridge regenerated, ran `./tools/scripts/build.sh codegen`

## Notes for Reviewer

- On Windows, the resolution order is:
  1. `NAPAXI_BASH`
  2. Bash locations inferred from `PATH`
  3. Common Git installation locations under `Program Files`, `Program Files (x86)`, and `LocalAppData`
- The implementation intentionally avoids `C:\Windows\System32\bash.exe`, which may resolve to WSL-related behavior rather than a usable Git Bash executable for this build flow.
- No public API changes are included in this PR.