### PR TITLE
Fix sandbox file deletion path escapefix: constrain sandbox file deletion paths

### DIFF
--- a/crates/core/src/storage/bridge.rs
+++ b/crates/core/src/storage/bridge.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::StorageError;
 
@@ -76,18 +76,24 @@ impl FileBridge {
     }
 
     pub fn sandbox_to_real(&self, sandbox_path: &str) -> Option<String> {
-        if sandbox_path == "/workspace" || sandbox_path.starts_with("/workspace/") {
-            return Some(join_mapped(&self.workspace_dir, sandbox_path, "/workspace"));
+        if is_sandbox_root_or_child(sandbox_path, "/workspace") {
+            return join_mapped(&self.workspace_dir, sandbox_path, "/workspace")
+                .ok()
+                .map(|path| path.display().to_string());
         }
-        if sandbox_path == "/skills" || sandbox_path.starts_with("/skills/") {
-            return Some(join_mapped(&self.skills_dir, sandbox_path, "/skills"));
+        if is_sandbox_root_or_child(sandbox_path, "/skills") {
+            return join_mapped(&self.skills_dir, sandbox_path, "/skills")
+                .ok()
+                .map(|path| path.display().to_string());
         }
         if ROOTFS_PREFIXES
             .iter()
-            .any(|prefix| sandbox_path.starts_with(prefix))
+            .any(|prefix| is_sandbox_root_or_child(sandbox_path, prefix))
         {
             let rest = sandbox_path.strip_prefix('/').unwrap_or(sandbox_path);
-            return Some(self.rootfs_dir.join(rest).display().to_string());
+            return join_validated(&self.rootfs_dir, rest, sandbox_path)
+                .ok()
+                .map(|path| path.display().to_string());
         }
         None
     }
@@ -111,16 +117,40 @@ impl FileBridge {
     }
 }
 
-fn join_mapped(base: &Path, sandbox_path: &str, prefix: &str) -> String {
+fn is_sandbox_root_or_child(sandbox_path: &str, root: &str) -> bool {
+    sandbox_path == root
+        || sandbox_path
+            .strip_prefix(root)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+fn join_mapped(base: &Path, sandbox_path: &str, prefix: &str) -> Result<PathBuf, StorageError> {
     let rest = sandbox_path
         .strip_prefix(prefix)
         .unwrap_or("")
         .strip_prefix('/')
         .unwrap_or("");
-    if rest.is_empty() {
-        base.display().to_string()
+    join_validated(base, rest, sandbox_path)
+}
+
+fn join_validated(
+    base: &Path,
+    relative_path: &str,
+    sandbox_path: &str,
+) -> Result<PathBuf, StorageError> {
+    let relative_path = Path::new(relative_path);
+    if relative_path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::CurDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(StorageError::OutsideSandbox(sandbox_path.to_string()));
+    }
+    if relative_path.as_os_str().is_empty() {
+        Ok(base.to_path_buf())
     } else {
-        base.join(rest).display().to_string()
+        Ok(base.join(relative_path))
     }
 }
 
@@ -177,17 +207,65 @@ pub(crate) fn delete_sandbox_file_with_bridge_inner(
     bridge: &FileBridge,
     sandbox_path: &str,
 ) -> Result<(), StorageError> {
-    let Some(real) = bridge.sandbox_to_real(sandbox_path) else {
+    let Some((path, base)) = delete_target(bridge, sandbox_path)? else {
         return Ok(());
     };
-    let path = Path::new(&real);
-    if !path.exists() {
-        return Ok(());
-    }
-    if path.is_dir() {
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    ensure_delete_target_inside_base(&path, &base, &metadata, sandbox_path)?;
+    if metadata.file_type().is_symlink() {
+        fs::remove_file(path)?;
+    } else if metadata.is_dir() {
         fs::remove_dir_all(path)?;
     } else {
         fs::remove_file(path)?;
     }
     Ok(())
+}
+
+fn delete_target(
+    bridge: &FileBridge,
+    sandbox_path: &str,
+) -> Result<Option<(PathBuf, PathBuf)>, StorageError> {
+    if is_sandbox_root_or_child(sandbox_path, "/workspace") {
+        return join_mapped(&bridge.workspace_dir, sandbox_path, "/workspace")
+            .map(|path| Some((path, bridge.workspace_dir.clone())));
+    }
+    if is_sandbox_root_or_child(sandbox_path, "/skills") {
+        return Err(StorageError::OutsideSandbox(sandbox_path.to_string()));
+    }
+    if ROOTFS_PREFIXES
+        .iter()
+        .any(|prefix| is_sandbox_root_or_child(sandbox_path, prefix))
+    {
+        let rest = sandbox_path.strip_prefix('/').unwrap_or(sandbox_path);
+        return join_validated(&bridge.rootfs_dir, rest, sandbox_path)
+            .map(|path| Some((path, bridge.rootfs_dir.clone())));
+    }
+    Ok(None)
+}
+
+fn ensure_delete_target_inside_base(
+    path: &Path,
+    base: &Path,
+    metadata: &fs::Metadata,
+    sandbox_path: &str,
+) -> Result<(), StorageError> {
+    let canonical_base = base.canonicalize()?;
+    let canonical_guard = if metadata.file_type().is_symlink() {
+        path.parent()
+            .unwrap_or(base)
+            .canonicalize()
+            .map_err(StorageError::from)?
+    } else {
+        path.canonicalize()?
+    };
+    if canonical_guard == canonical_base || canonical_guard.starts_with(&canonical_base) {
+        Ok(())
+    } else {
+        Err(StorageError::OutsideSandbox(sandbox_path.to_string()))
+    }
 }

--- a/crates/core/src/storage/tests.rs
+++ b/crates/core/src/storage/tests.rs
@@ -75,6 +75,11 @@ fn maps_sandbox_paths_to_mobile_filesystem() {
     let tmp = bridge.sandbox_to_real("/tmp/a.txt").unwrap();
     assert!(tmp.ends_with("linux-env/rootfs/tmp/a.txt"));
     assert_eq!(bridge.real_to_sandbox(&tmp).as_deref(), Some("/tmp/a.txt"));
+
+    assert!(bridge.sandbox_to_real("/workspace/../escape.txt").is_none());
+    assert!(bridge.sandbox_to_real("/workspace//escape.txt").is_none());
+    assert!(bridge.sandbox_to_real("/tmp/../escape.txt").is_none());
+    assert!(bridge.sandbox_to_real("/tmpfile/a.txt").is_none());
 }
 
 #[test]
@@ -321,6 +326,39 @@ fn imports_lists_detects_sizes_and_deletes_workspace_files() {
     assert!(delete_sandbox_file(&files_dir, &sandbox_path));
     assert!(!Path::new(&real_path).exists());
     assert_eq!(workspace_size(&files_dir), 0);
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn delete_sandbox_file_rejects_workspace_path_escape() {
+    let dir = temp_dir("delete_escape");
+    let files_dir = dir.to_string_lossy().to_string();
+    let bridge = FileBridge::new(&files_dir);
+    fs::create_dir_all(bridge.workspace_dir()).unwrap();
+    fs::create_dir_all(&dir).unwrap();
+    let outside = dir.join("outside.txt");
+    fs::write(&outside, "keep me").unwrap();
+
+    assert!(!delete_sandbox_file(
+        &files_dir,
+        "/workspace/../../outside.txt"
+    ));
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "keep me");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn delete_sandbox_file_keeps_skills_read_only() {
+    let dir = temp_dir("delete_skills");
+    let files_dir = dir.to_string_lossy().to_string();
+    let skill_file = dir.join("prompt_skills/demo/SKILL.md");
+    fs::create_dir_all(skill_file.parent().unwrap()).unwrap();
+    fs::write(&skill_file, "skill").unwrap();
+
+    assert!(!delete_sandbox_file(&files_dir, "/skills/demo/SKILL.md"));
+    assert_eq!(fs::read_to_string(&skill_file).unwrap(), "skill");
 
     let _ = fs::remove_dir_all(dir);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Napaxi! Please complete this template — fields marked
with * are required. See CONTRIBUTING.md for the full PR expectations.
-->

## Summary *

- Harden `FileBridge` sandbox path resolution to reject path traversal and invalid sandbox root matches.
- Constrain `delete_sandbox_file` deletion targets to the workspace/rootfs sandbox and keep `/skills` read-only.
- Add regression tests covering workspace path escape deletion and `/skills` deletion protection.

## Motivation

`delete_sandbox_file` is exposed through the SDK file bridge, so it must enforce the same sandbox boundary as the rest of the file APIs. Before this change, paths such as `/workspace/../../...` could be mapped to real filesystem locations outside the intended workspace before deletion. The delete path also did not preserve `/skills` as a read-only sandbox area.

This change closes that boundary gap while preserving idempotent deletion for missing files and normal workspace file deletion behavior.

## Scope *

- [ ] Core (`crates/core/`)
- [ ] Feature crate (`crates/features/`)
- [ ] Bridge (`packages/api_bridge/`)
- [ ] Flutter SDK (`packages/flutter/`)
- [ ] Agent Provider (`packages/agent_provider/`)
- [ ] Demo (`examples/`)
- [ ] Docs / scripts only

## Test Plan *

- `cargo fmt --manifest-path crates/core/Cargo.toml -- --check`
- `git diff --check`
- `cargo test -p napaxi_core storage::tests` could not complete locally because crates.io dependency download timed out; offline mode was missing cached package `quote`.

## Contributor License Agreement *

<!-- External contributors must complete the applicable CLA before merge. See CLA.md. -->

- [ ] I have completed the applicable CLA, or this PR is from a maintainer using
      already-approved project-owned code.
- [ ] If this contribution is owned or controlled by my employer or another
      legal entity, the Corporate CLA requirement has been addressed.

## Capability / API Surface

<!-- If this adds or changes an LLM provider, built-in tool, platform tool, MCP
surface, policy hook, or background service: -->

- [ ] Capability defined in `crates/core/src/capabilities/`
- [ ] Adapter wrapper in `crates/core/src/api/`
- [ ] `docs/mobile-capabilities.md` updated
- [ ] Public Dart SDK surface in `packages/flutter/lib/napaxi_flutter.dart` unchanged
      (or breaking change is called out below and added to `CHANGELOG.md`)

## Generated Code

- [ ] No hand edits to `packages/flutter/lib/generated/`, `packages/api_bridge/generated/`,
      or `packages/flutter/ios/Classes/frb_generated.h`
- [ ] If bridge regenerated, ran `./tools/scripts/build.sh codegen`

## Notes for Reviewer

<!-- Anything else worth flagging: known follow-ups, alternative approaches
considered, areas needing extra scrutiny. -->
