### PR TITLE
feat(demo): support managed model profiles

### DIFF
--- a/examples/flutter/lib/models/llm_models.dart
+++ b/examples/flutter/lib/models/llm_models.dart
@@ -85,6 +85,7 @@ class LlmModelProfile {
     this.responseReserveTokens,
     this.compactionModel = '',
     this.preCompactionMemoryFlush = false,
+    this.isUserEditable = true,
   }) : _defaultChatModel = model;
 
   final String id;
@@ -103,6 +104,7 @@ class LlmModelProfile {
   final int? responseReserveTokens;
   final String compactionModel;
   final bool preCompactionMemoryFlush;
+  final bool isUserEditable;
 
   String get model => selectedModel(ModelCapability.chat) ?? _defaultChatModel;
 
@@ -467,6 +469,7 @@ class LlmConfigState {
       responseReserveTokens: contextEngine.responseReserveTokens,
       compactionModel: contextEngine.compactionModel ?? '',
       preCompactionMemoryFlush: contextEngine.preCompactionMemoryFlush,
+      isUserEditable: chatProfile.isUserEditable,
     );
   }
 
@@ -477,6 +480,7 @@ class LlmConfigState {
 
 const _storedModelEntriesKey = 'model_entries';
 const _storedSelectedModelByCapabilityKey = 'selected_model_by_capability';
+const _storedUserEditableKey = 'user_editable';
 
 sdk.NapaxiConfigProfile _storedProfileFromProfile(LlmModelProfile profile) {
   final allowedModels = profile.models
@@ -523,6 +527,7 @@ sdk.NapaxiConfigProfile _storedProfileFromProfile(LlmModelProfile profile) {
         for (final entry in profile.selectedModelByCapability.entries)
           entry.key.name: entry.value,
       },
+      _storedUserEditableKey: profile.isUserEditable,
     },
   );
 }
@@ -549,7 +554,13 @@ LlmModelProfile _profileFromStoredProfile(
     responseReserveTokens: profile.contextEngine.responseReserveTokens,
     compactionModel: profile.contextEngine.compactionModel ?? '',
     preCompactionMemoryFlush: profile.contextEngine.preCompactionMemoryFlush,
+    isUserEditable: _userEditableFromMetadata(profile),
   );
+}
+
+bool _userEditableFromMetadata(sdk.NapaxiConfigProfile profile) {
+  final value = profile.metadata[_storedUserEditableKey];
+  return value is bool ? value : true;
 }
 
 List<ModelEntry> _modelEntriesFromMetadata(sdk.NapaxiConfigProfile profile) {

--- a/examples/flutter/lib/panels/session_history.dart
+++ b/examples/flutter/lib/panels/session_history.dart
@@ -2566,6 +2566,7 @@ class _SettingsPageState extends State<_SettingsPage>
   }
 
   void _editModel(LlmModelProfile profile) {
+    if (!profile.isUserEditable) return;
     _editingProfile = profile;
     _editingCapability = null;
     _editingNewModel = false;
@@ -2573,6 +2574,7 @@ class _SettingsPageState extends State<_SettingsPage>
   }
 
   Future<void> _deleteModel(LlmModelProfile profile) async {
+    if (!profile.isUserEditable) return;
     final selectedCapabilities = <ModelCapability>[
       for (final capability in _visibleModelCapabilities)
         if (_config.selectedProfileFor(capability)?.id == profile.id)
@@ -2641,6 +2643,10 @@ class _SettingsPageState extends State<_SettingsPage>
   }
 
   void _saveModelEditor(LlmModelProfile profile) {
+    if (!_editingNewModel && _editingProfile?.isUserEditable == false) {
+      unawaited(_animateBackToMenu());
+      return;
+    }
     final profiles = _editingNewModel
         ? [..._config.profiles, profile]
         : [
@@ -4760,7 +4766,7 @@ class _ModelManagementRow extends StatelessWidget {
     final subtitle = profile.subtitle;
     return InkWell(
       key: Key('settings_model_profile_${profile.id}'),
-      onTap: onEdit,
+      onTap: profile.isUserEditable ? onEdit : null,
       child: ConstrainedBox(
         constraints: const BoxConstraints(minHeight: 66),
         child: Padding(
@@ -4820,56 +4826,65 @@ class _ModelManagementRow extends StatelessWidget {
                   ],
                 ),
               ),
-              PopupMenuButton<_ModelManagementAction>(
-                key: Key('settings_model_profile_menu_${profile.id}'),
-                tooltip: MaterialLocalizations.of(context).showMenuTooltip,
-                color: _configSurface,
-                surfaceTintColor: Colors.transparent,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                icon: const Icon(
-                  Icons.more_horiz_rounded,
-                  color: _configTextSecondary,
-                ),
-                onSelected: (action) {
-                  switch (action) {
-                    case _ModelManagementAction.edit:
-                      onEdit();
-                    case _ModelManagementAction.delete:
-                      onDelete();
-                  }
-                },
-                itemBuilder: (context) => [
-                  PopupMenuItem(
-                    value: _ModelManagementAction.edit,
-                    child: Row(
-                      children: [
-                        const Icon(Icons.edit_outlined, size: 20),
-                        const SizedBox(width: 12),
-                        Text(chinese ? '编辑' : 'Edit'),
-                      ],
-                    ),
+              if (!profile.isUserEditable)
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: Icon(
+                    Icons.lock_outline_rounded,
+                    color: _configTextSecondary,
                   ),
-                  PopupMenuItem(
-                    value: _ModelManagementAction.delete,
-                    child: Row(
-                      children: [
-                        const Icon(
-                          Icons.delete_outline_rounded,
-                          size: 20,
-                          color: Color(0xFFB42318),
-                        ),
-                        const SizedBox(width: 12),
-                        Text(
-                          chinese ? '删除' : 'Delete',
-                          style: const TextStyle(color: Color(0xFFB42318)),
-                        ),
-                      ],
-                    ),
+                )
+              else
+                PopupMenuButton<_ModelManagementAction>(
+                  key: Key('settings_model_profile_menu_${profile.id}'),
+                  tooltip: MaterialLocalizations.of(context).showMenuTooltip,
+                  color: _configSurface,
+                  surfaceTintColor: Colors.transparent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
                   ),
-                ],
-              ),
+                  icon: const Icon(
+                    Icons.more_horiz_rounded,
+                    color: _configTextSecondary,
+                  ),
+                  onSelected: (action) {
+                    switch (action) {
+                      case _ModelManagementAction.edit:
+                        onEdit();
+                      case _ModelManagementAction.delete:
+                        onDelete();
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      value: _ModelManagementAction.edit,
+                      child: Row(
+                        children: [
+                          const Icon(Icons.edit_outlined, size: 20),
+                          const SizedBox(width: 12),
+                          Text(chinese ? '编辑' : 'Edit'),
+                        ],
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: _ModelManagementAction.delete,
+                      child: Row(
+                        children: [
+                          const Icon(
+                            Icons.delete_outline_rounded,
+                            size: 20,
+                            color: Color(0xFFB42318),
+                          ),
+                          const SizedBox(width: 12),
+                          Text(
+                            chinese ? '删除' : 'Delete',
+                            style: const TextStyle(color: Color(0xFFB42318)),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
             ],
           ),
         ),

--- a/examples/flutter/lib/screens/config_screen.dart
+++ b/examples/flutter/lib/screens/config_screen.dart
@@ -211,6 +211,7 @@ class _LlmConfigPageState extends State<_LlmConfigPage> {
   }
 
   Future<void> _editProfile(LlmModelProfile profile) async {
+    if (!profile.isUserEditable) return;
     final updatedProfile = await Navigator.of(context).push<LlmModelProfile>(
       MaterialPageRoute(
         builder: (context) => _LlmModelProfilePage(initialProfile: profile),
@@ -237,6 +238,11 @@ class _LlmConfigPageState extends State<_LlmConfigPage> {
   }
 
   void _deleteProfile(String profileId) {
+    if (_profiles.any(
+      (profile) => profile.id == profileId && !profile.isUserEditable,
+    )) {
+      return;
+    }
     setState(() {
       _profiles = _profiles
           .where((profile) => profile.id != profileId)
@@ -329,8 +335,12 @@ class _LlmConfigPageState extends State<_LlmConfigPage> {
                 profile: profile,
                 isSelected: profile.id == _normalizedSelectedProfileId,
                 onSelect: () => _selectProfile(profile.id),
-                onEdit: () => _editProfile(profile),
-                onDelete: () => _deleteProfile(profile.id),
+                onEdit: profile.isUserEditable
+                    ? () => _editProfile(profile)
+                    : null,
+                onDelete: profile.isUserEditable
+                    ? () => _deleteProfile(profile.id)
+                    : null,
               );
             }),
           const SizedBox(height: 24),
@@ -579,8 +589,8 @@ class _ModelProfileTile extends StatelessWidget {
   final LlmModelProfile profile;
   final bool isSelected;
   final VoidCallback onSelect;
-  final VoidCallback onEdit;
-  final VoidCallback onDelete;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -642,26 +652,37 @@ class _ModelProfileTile extends StatelessWidget {
                     ],
                   ),
                 ),
-                IconButton(
-                  key: Key('edit_model_${profile.id}'),
-                  tooltip: strings.editModel,
-                  onPressed: onEdit,
-                  icon: const Icon(
-                    Icons.edit_outlined,
-                    color: _configTextSecondary,
-                    size: 20,
+                if (!profile.isUserEditable)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 12),
+                    child: Icon(
+                      Icons.lock_outline_rounded,
+                      color: _configTextSecondary,
+                      size: 20,
+                    ),
+                  )
+                else ...[
+                  IconButton(
+                    key: Key('edit_model_${profile.id}'),
+                    tooltip: strings.editModel,
+                    onPressed: onEdit,
+                    icon: const Icon(
+                      Icons.edit_outlined,
+                      color: _configTextSecondary,
+                      size: 20,
+                    ),
                   ),
-                ),
-                IconButton(
-                  key: Key('delete_model_${profile.id}'),
-                  tooltip: strings.deleteModel,
-                  onPressed: onDelete,
-                  icon: const Icon(
-                    Icons.delete_outline,
-                    color: _configTextSecondary,
-                    size: 20,
+                  IconButton(
+                    key: Key('delete_model_${profile.id}'),
+                    tooltip: strings.deleteModel,
+                    onPressed: onDelete,
+                    icon: const Icon(
+                      Icons.delete_outline,
+                      color: _configTextSecondary,
+                      size: 20,
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),
@@ -783,6 +804,7 @@ class _LlmModelProfilePageState extends State<_LlmModelProfilePage> {
       selectedModelByCapability: const {},
       systemPrompt: widget.initialProfile.systemPrompt,
       maxTokens: _configuredMaxTokens,
+      isUserEditable: widget.initialProfile.isUserEditable,
     );
     final onSaved = widget.onSaved;
     if (onSaved != null) {

--- a/examples/flutter/test/widget_test.dart
+++ b/examples/flutter/test/widget_test.dart
@@ -2325,6 +2325,70 @@ void main() {
     );
   });
 
+  testWidgets('selects managed models without exposing edit actions', (
+    tester,
+  ) async {
+    final store = sdk.NapaxiConfigStore.memory();
+    await store.saveProfile(
+      const sdk.NapaxiConfigProfile(
+        id: 'managed-model',
+        name: 'Managed model',
+        provider: 'openai-compatible',
+        model: 'managed-model-id',
+        metadata: {'user_editable': false},
+      ),
+      apiKey: 'managed-token',
+    );
+    await store.saveProfile(
+      const sdk.NapaxiConfigProfile(
+        id: 'user-model',
+        name: 'User model',
+        provider: 'openai',
+        model: 'user-model-id',
+      ),
+      apiKey: 'user-token',
+    );
+    await store.saveSelection(
+      const sdk.NapaxiConfigSelection(selectedProfileId: 'user-model'),
+    );
+    final fakeClient = FakeNapaxiChatClient();
+
+    await tester.pumpWidget(
+      _testApp(configStore: store, chatClientFactory: () async => fakeClient),
+    );
+    await tester.pumpAndSettle();
+    await openModelConfiguration(tester);
+
+    expect(
+      find.byKey(const Key('model_profile_managed-model')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('edit_model_managed-model')), findsNothing);
+    expect(find.byKey(const Key('delete_model_managed-model')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('model_profile_managed-model')));
+    await tester.pumpAndSettle();
+    expect((await store.loadSelection()).selectedProfileId, 'managed-model');
+    await closeSettingsSheet(tester);
+
+    await tester.enterText(
+      find.byKey(const Key('chat_input_field')),
+      'Use managed model',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('send_message_button')));
+    await tester.pumpAndSettle();
+
+    expect(fakeClient.configuredProfile?.model, 'managed-model-id');
+    expect(
+      find.text(
+        'Fake SDK reply from managed-model-id: Use managed model',
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('restores saved model configuration after rebuild', (
     tester,
   ) async {


### PR DESCRIPTION
<!--
Thanks for contributing to Napaxi! Please complete this template — fields marked
with * are required. See CONTRIBUTING.md for the full PR expectations.
-->

## Summary *

<!-- One or two sentences describing the change and the user impact. -->

## Motivation

<!-- Linked issue, design discussion, or short description of why. Use
"Fixes #123" / "Refs #123" to auto-link. -->

## Scope *

- [ ] Core (`crates/core/`)
- [ ] Feature crate (`crates/features/`)
- [ ] Bridge (`packages/api_bridge/`)
- [ ] Flutter SDK (`packages/flutter/`)
- [ ] Agent Provider (`packages/agent_provider/`)
- [ ] Demo (`examples/`)
- [ ] Docs / scripts only

## Test Plan *

<!-- What did you run locally? Paste the commands and outcomes. -->

- [ ] `./tools/scripts/build.sh check-boundary`
- [ ] `cargo check --workspace`
- [ ] `cargo test --workspace` (if behavior changed)
- [ ] `cd packages/flutter && flutter analyze --no-fatal-infos && flutter test` (if Flutter SDK changed)
- [ ] `cd examples/flutter && flutter analyze --no-fatal-infos && flutter test` (if demo changed)

## Contributor License Agreement *

<!-- External contributors must complete the applicable CLA before merge. See CLA.md. -->

- [ ] I have completed the applicable CLA, or this PR is from a maintainer using
      already-approved project-owned code.
- [ ] If this contribution is owned or controlled by my employer or another
      legal entity, the Corporate CLA requirement has been addressed.

## Capability / API Surface

<!-- If this adds or changes an LLM provider, built-in tool, platform tool, MCP
surface, policy hook, or background service: -->

- [ ] Capability defined in `crates/core/src/capabilities/`
- [ ] Adapter wrapper in `crates/core/src/api/`
- [ ] `docs/mobile-capabilities.md` updated
- [ ] Public Dart SDK surface in `packages/flutter/lib/napaxi_flutter.dart` unchanged
      (or breaking change is called out below and added to `CHANGELOG.md`)

## Generated Code

- [ ] No hand edits to `packages/flutter/lib/generated/`, `packages/api_bridge/generated/`,
      or `packages/flutter/ios/Classes/frb_generated.h`
- [ ] If bridge regenerated, ran `./tools/scripts/build.sh codegen`

## Notes for Reviewer

<!-- Anything else worth flagging: known follow-ups, alternative approaches
considered, areas needing extra scrutiny. -->
